### PR TITLE
Fix Spring Forward bug

### DIFF
--- a/lib/clockwork/event.rb
+++ b/lib/clockwork/event.rb
@@ -21,7 +21,12 @@ module Clockwork
 
     def run_now?(t)
       t = convert_timezone(t)
-      elapsed_ready(t) and (@at.nil? or @at.ready?(t)) and (@if.nil? or @if.call(t))
+      
+      if @at.nil?
+        elapsed_ready(t) and (@if.nil? or @if.call(t))
+      else
+        @at.ready?(t) and (@if.nil? or @if.call(t))
+      end
     end
 
     def thread?

--- a/test/database_events/synchronizer_test.rb
+++ b/test/database_events/synchronizer_test.rb
@@ -167,8 +167,9 @@ describe Clockwork::DatabaseEvents::Synchronizer do
           DatabaseEventModel.create(:frequency => 1.day, :at => next_minute(@now).strftime('%H:%M'))
           setup_sync(model: DatabaseEventModel, :every => @sync_frequency, :events_run => @events_run)
 
-          # tick from now, though specified :at time
-          tick_at(@now, :and_every_second_for => (2 * @sync_frequency) + 1.second)
+          tick_at(@now)
+          tick_at(next_minute(@now))
+          tick_at(next_minute(next_minute(@now)))
 
           assert_equal 1, @events_run.length
         end
@@ -180,7 +181,9 @@ describe Clockwork::DatabaseEvents::Synchronizer do
           setup_sync(model: DatabaseEventModelWithoutName, :every => @sync_frequency, :events_run => @events_run)
 
           # tick from now, though specified :at time
-          tick_at(@now, :and_every_second_for => (2 * @sync_frequency) + 1.second)
+          tick_at(@now)
+          tick_at(next_minute(@now))
+          tick_at(next_minute(next_minute(@now)))
 
           assert_equal 1, @events_run.length
         end
@@ -192,13 +195,13 @@ describe Clockwork::DatabaseEvents::Synchronizer do
 
         tick_at @now, :and_every_second_for => 1.second
 
-        assert_wont_run 'jan 1 2010 16:19:59'
+        assert_wont_run 'jan 1 2010 16:19:00'
         assert_will_run 'jan 1 2010 16:20:00'
-        assert_wont_run 'jan 1 2010 16:20:01'
+        assert_wont_run 'jan 1 2010 16:21:00'
 
-        assert_wont_run 'jan 1 2010 18:09:59'
+        assert_wont_run 'jan 1 2010 18:09:00'
         assert_will_run 'jan 1 2010 18:10:00'
-        assert_wont_run 'jan 1 2010 18:10:01'
+        assert_wont_run 'jan 1 2010 18:11:00'
       end
 
       it 'allows syncing multiple database models' do
@@ -281,7 +284,7 @@ describe Clockwork::DatabaseEvents::Synchronizer do
 
       it 'runs the event based on America/Montreal tz' do
         begin
-          tick_at(@utc_time_now, :and_every_second_for => 5.hours)
+          tick_at(@utc_time_now, :and_every_minute_for => 5.hours)
         rescue
         end
         assert_equal 1, @events_run.length

--- a/test/database_events/test_helpers.rb
+++ b/test/database_events/test_helpers.rb
@@ -21,8 +21,16 @@ end
 
 def tick_at(now = Time.now, options = {})
   seconds_to_tick_for = options[:and_every_second_for] || 0
-  number_of_ticks = 1 + seconds_to_tick_for
-  number_of_ticks.times{|i| @manager.tick(now + i) }
+  minutes_to_tick_for = options[:and_every_minute_for] || 0
+  if seconds_to_tick_for > 0
+    number_of_ticks = 1 + seconds_to_tick_for
+    number_of_ticks.times{|i| @manager.tick(now + i) }
+  elsif minutes_to_tick_for > 0
+    number_of_ticks = 1 + (minutes_to_tick_for.to_i / 60)
+    number_of_ticks.times{|i| @manager.tick(now + i*60) }
+  else
+    @manager.tick(now)
+  end
 end
 
 def next_minute(now = Time.now)

--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -167,23 +167,23 @@ describe Clockwork::Manager do
     it "once a day at 16:20" do
       @manager.every(1.day, 'myjob', :at => '16:20')
 
-      assert_wont_run 'jan 1 2010 16:19:59'
+      assert_wont_run 'jan 1 2010 16:19:00'
       assert_will_run 'jan 1 2010 16:20:00'
-      assert_wont_run 'jan 1 2010 16:20:01'
-      assert_wont_run 'jan 2 2010 16:19:59'
+      assert_wont_run 'jan 1 2010 16:21:00'
+      assert_wont_run 'jan 2 2010 16:19:00'
       assert_will_run 'jan 2 2010 16:20:00'
     end
 
     it "twice a day at 16:20 and 18:10" do
       @manager.every(1.day, 'myjob', :at => ['16:20', '18:10'])
 
-      assert_wont_run 'jan 1 2010 16:19:59'
+      assert_wont_run 'jan 1 2010 16:19:00'
       assert_will_run 'jan 1 2010 16:20:00'
-      assert_wont_run 'jan 1 2010 16:20:01'
+      assert_wont_run 'jan 1 2010 16:21:00'
 
-      assert_wont_run 'jan 1 2010 18:09:59'
+      assert_wont_run 'jan 1 2010 18:09:00'
       assert_will_run 'jan 1 2010 18:10:00'
-      assert_wont_run 'jan 1 2010 18:10:01'
+      assert_wont_run 'jan 1 2010 18:11:00'
     end
   end
 


### PR DESCRIPTION
/domain @smudge @ceslami @Jaco-Pretorius @aburgel @samandmoore @pat-whitrock 
/no-platform

First swipe at fixing the spring forward bug, where daily tasks with an `at:` set would not run after daylight savings (essentially because it hadn't been 24 hours since it was last run). This change tells clockwork to ignore any in-memory periodicity tracking if `at` is set.

One side effect is that daily tasks with a specific `at:` will not work properly if clockwork tics every second. however, we enforce clockwork ticking every minute (but i had to update tests that explicitly tests what happens when clock tics every second).

I think there is a lot more to clean up here: we probably should never rely on periodicity (because it is in memory and gets wiped away on every deploy), and we should do more to enforce the limited subset of functionality we use here (ie, having a tic every minute, only using either 1.minute or 1.day events that specify `at`)

I will take a crack at that further cleanup, but wanted to open this pr because I think it solves the most severe issue for us, and I don't want to block fixing that bug on a more ambitious refactor.